### PR TITLE
Separating V2 and V3 docs. Also only displaying the swagger docs when…

### DIFF
--- a/site-templates/fragments/navigation.gohtml
+++ b/site-templates/fragments/navigation.gohtml
@@ -8,6 +8,7 @@
       {{$haveOther = true}}
     {{end}}
   {{end}}
+    {{if (eq $.CurrentPage "reference")}}
     <div>
         <strong>Bluescape v3 APIs</strong>
         <ul class="unindent-side-nav-ul">
@@ -18,11 +19,15 @@
                 {{$class = "c-nav__selected"}}
             {{end}}
             {{if $element.Metadata.HasDoc}}
-            <li>
-                <a class="{{$class}}" href="{{$.Prefix}}doc/{{$svc.Namespace}}/{{$svc.Name}}">
-                    {{$svc.Namespace}}.{{$svc.Name}}
-                </a>
-            </li>
+                {{if or (eq $svc.Name "elementary") (eq $svc.Name "isam")}}
+                    <li>
+                        <a class="{{$class}}" href="{{$.Prefix}}doc/{{$svc.Namespace}}/{{$svc.Name}}">
+                            {{$svc.Namespace}}.{{$svc.Name}}
+                        </a>
+                    </li>
+                {{else}}
+                    <li><samp>None</samp></li> 
+                {{end}}
             {{end}}
         {{end}}
         {{if not $haveApi}}
@@ -30,6 +35,33 @@
         {{end}}
         </ul>
     </div>
+    <div>
+        <strong>Bluescape v2 APIs</strong>
+        <ul class="unindent-side-nav-ul">
+        {{range $i, $element := .S.K8sStore.Slice }}
+            {{$svc := $element.Service}}
+            {{$class := ""}}
+            {{if and (eq $.CurrentService $svc.Name) (eq $.CurrentNamespace $svc.Namespace)}}
+                {{$class = "c-nav__selected"}}
+            {{end}}
+            {{if $element.Metadata.HasDoc}}
+                {{if or (eq $svc.Name "collab") (eq $svc.Name "identity-api") (eq $svc.Name "portal-api") (eq $svc.Name "listener-api")}}
+                <li>
+                    <a class="{{$class}}" href="{{$.Prefix}}doc/{{$svc.Namespace}}/{{$svc.Name}}">
+                        {{$svc.Namespace}}.{{$svc.Name}}
+                    </a>
+                </li>
+                {{else}}
+                    <li><samp>None</samp></li> 
+                {{end}}
+            {{end}} 
+        {{end}}
+        {{if not $haveApi}}
+        <li><samp>None</samp></li>
+        {{end}}
+        </ul>
+    </div>
+    {{end}}
     <br />
     {{if or (eq $.CurrentPage "reference") (eq $.CurrentPage "urls") (eq $.CurrentPage "pagination") (eq $.CurrentPage "listener-events") (eq $.CurrentPage "permissions") (eq $.CurrentPage "versioning")}}
     <div>

--- a/site-templates/pages/overview.gomd
+++ b/site-templates/pages/overview.gomd
@@ -5,9 +5,9 @@
     <h1>Overview</h1>
 
     <p>The Bluescape API is a <a href="/docs/page/reference">REST API</a> that can be accessed through explicit HTTP calls. These APIs expose most of the features available in the Bluescape product. The Bluescape API enables developers to programmatically create, upload, and update content within Bluescape workspaces. Applications are able to pull data and files from external sources like databases, content management systems and cloud storage and push them into Bluescape workspaces with ease. Organizations are free to move beyond the Bluescape web and wall interfaces for integrating the Bluescape visual layer into their collaboration and decision-making processes.</p>
-
+    <!--
     <p>In addition, the Bluescape API enables applications to register <a href="/docs/page/graphql-not-yet-created">GraphQL subscriptions</a> for Bluescape workspaces that will be notified whenever content or comments are created, updated or deleted. Subscriptions are key to integrating Bluescape with the communication platforms that organizations use to keep their project teams connected and informed. Using these GraphQL Subscriptions, developers can easily translate actions taken in Bluescape workspaces into emails, chat messages, database updates, and much more.</p>
-
+    -->
     <h3>Basic Concepts</h3>
 
     <p>

--- a/site-templates/pages/overview.gomd.debughtml
+++ b/site-templates/pages/overview.gomd.debughtml
@@ -5,9 +5,9 @@
     <h1>Overview</h1>
 
     <p>The Bluescape API is a <a href="/docs/page/reference">REST API</a> that can be accessed through explicit HTTP calls. These APIs expose most of the features available in the Bluescape product. The Bluescape API enables developers to programmatically create, upload, and update content within Bluescape workspaces. Applications are able to pull data and files from external sources like databases, content management systems and cloud storage and push them into Bluescape workspaces with ease. Organizations are free to move beyond the Bluescape web and wall interfaces for integrating the Bluescape visual layer into their collaboration and decision-making processes.</p>
-
+    <!--
     <p>In addition, the Bluescape API enables applications to register <a href="/docs/page/graphql-not-yet-created">GraphQL subscriptions</a> for Bluescape workspaces that will be notified whenever content or comments are created, updated or deleted. Subscriptions are key to integrating Bluescape with the communication platforms that organizations use to keep their project teams connected and informed. Using these GraphQL Subscriptions, developers can easily translate actions taken in Bluescape workspaces into emails, chat messages, database updates, and much more.</p>
-
+    -->
     <h3>Basic Concepts</h3>
 
     <p>


### PR DESCRIPTION
… user is on References page. Also commented out GraphQL subscription paragraph in Overview for now