### PR TITLE
Update Reference Landing Page

### DIFF
--- a/site-templates/pages/reference.gomd
+++ b/site-templates/pages/reference.gomd
@@ -5,14 +5,7 @@
     interfaces.
 </p>
 
-<p>
+<p style="margin-bottom: 16rem;">
     We intend for this reference to contain all essential information application developers require to successfully
     build integrations with the Bluescape API. Please <a href="/docs/page/support">let us know</a> if something is missing.
 </p>
-
-<h1> This is a Landing Page </h1>
-    <div style="background-color:powderblue;">
-        <p> This is just a temp directory to test out the side bar navigation. </p>
-        <p style="background-color:black; color:yellow;"> Yellow text Black background</p>
-    </div>
-

--- a/site-templates/pages/reference.gomd.debughtml
+++ b/site-templates/pages/reference.gomd.debughtml
@@ -5,13 +5,7 @@
     interfaces.
 </p></p>
 
-<p>
+<p style="margin-bottom: 16rem;">
     We intend for this reference to contain all essential information application developers require to successfully
     build integrations with the Bluescape API. Please <a href="/docs/page/support">let us know</a> if something is missing.
 </p>
-
-<p><h1> This is a Landing Page </h1>
-    <div style="background-color:powderblue;">
-        <p> This is just a temp directory to test out the side bar navigation. </p>
-        <p style="background-color:black; color:yellow;"> Yellow text Black background</p>
-    </div></p>


### PR DESCRIPTION
Remove unnecessary content from reference's landing page and add some spacing between the content and footer.