### PR TITLE
Adding links to REST and GraphQL sections

### DIFF
--- a/site-templates/pages/basic-api-requests.gomd
+++ b/site-templates/pages/basic-api-requests.gomd
@@ -7,7 +7,7 @@
     </em>
 </p>
 <p>
-  If you are looking for the GraphQL section of this guide, click <a href="#working-with-graphql">here</a>.
+  This page contains the details for <a href="#working-with-rest">REST APIs</a> and for <a href="#working-with-graphql">GraphQL APIs</a>.   
 </p>
 
 <h3>The Base URL</h3>
@@ -29,7 +29,7 @@
     OAuth flow. The value of this header should match the format of <span class="pre">Bearer &lt;access-token&gt;</span>.
 </p>
 
-<h2>Working with REST</h2>
+<a name="working-with-rest" class="internal-anchor"><h2>Implementation using REST APIs</h2></a>
 
 <h3>Assembling a REST Request</h3>
 
@@ -136,7 +136,7 @@ pprint.pprint(json_response)
 </pre>
 </p>
 
-<a name="working-with-graphql" class="internal-anchor"><h2>Working with GraphQL</h2></a>
+<a name="working-with-graphql" class="internal-anchor"><h2>Implementation using GraphQL APIs</h2></a>
 
 <h3>Assembling a GraphQL Query</h3>
 

--- a/site-templates/pages/create-canvas-and-add-text.gomd
+++ b/site-templates/pages/create-canvas-and-add-text.gomd
@@ -1,11 +1,11 @@
 <h1>Create a Canvas and add a Text Element to it</h1>
 
 <p>
-<b>Objective</b>: Create a new Canvas in your Workspace and add a Text element to this new Canvas. You will learn how to get the IDs of newly created objects within your Workspace, and how to use them to associate other objects with them. You will need the <span class="pre">workspaceId</span>.  
-If you are looking for the GraphQL section of this guide, click <a href="#graphql">here</a>.
+<b>Objective</b>: Create a new Canvas in your Workspace and add a Text element to this new Canvas. You will learn how to get the IDs of newly created objects within your Workspace, and how to use them to associate other objects with them. You will need the <span class="pre">workspaceId</span>.<br />  
+This page contains the implementation details for <a href="#rest">REST APIs</a> and for <a href="#graphql">GraphQL APIs</a>.
 </p>
 
-<h2>REST</h2>
+<a name="rest" class="internal-anchor"><h2>Implementation using REST APIs</h2></a>
 
 <h4>Create Canvas</h4>
 
@@ -384,14 +384,14 @@ From this response, you can obtain the newly created Canvas ID: ['data']['id']
 }
 </pre>
 
-<a name="graphql" class="internal-anchor"><h2>GraphQL</h2></a>
+<a name="graphql" class="internal-anchor"><h2>Implementation using GraphQL APIs</h2></a>
 
 <p>
     To begin, you will need to create a Canvas in your Workspace that can be used to group your elements in. To do this, you will need only the WorkspaceID
     in which you want to create the Canvas. For information on how to get this, see our previous guide on <a href="/docs/page/graphql-get-list-of-workspaces">Getting a List of Workspaces</a>.
     The information you'll need returned from this call is only the (x,y) coordinates of where it is placed, so that you can
     add a Text element to the Canvas in the next step. Many additional properties can be given to the Canvas upon creation, but it will be kept simple
-    for the sake of this introduction. This can be specifcied in a relatively simple query as follows:
+    for the sake of this introduction. This can be specified in a relatively simple query as follows:
 </p>
 
 <pre>

--- a/site-templates/pages/get-all-images-from-a-workspace.gomd
+++ b/site-templates/pages/get-all-images-from-a-workspace.gomd
@@ -1,11 +1,11 @@
 <h1>Get all the images from a workspace</h1>
 
 <p>
-<b>Objective</b>: get a list of all the images in a Workspace. You will need the Workspace ID. This list will contain, for each image, details such as: image name, creation date, traits, comments, etc.
-If you are looking for the GraphQL section of this guide, click <a href="#graphql">here</a>.
+<b>Objective</b>: get a list of all the images in a Workspace. You will need the Workspace ID. This list will contain, for each image, details such as: image name, creation date, traits, comments, etc.<br />
+This page contains the implementation details for <a href="#rest">REST APIs</a> and for <a href="#graphql">GraphQL APIs</a>.
 </p>
 
-<h2>REST</h2>
+<a name="rest" class="internal-anchor"><h2>Implementation using REST APIs</h2></a>
 
 <table class="table table-striped">
         <tr>
@@ -214,7 +214,7 @@ What you should get: JSON with the list of all images in the workspace
 } 
 </pre>
 
-<a name="graphql" class="internal-anchor"><h2>GraphQL</h2></a>
+<a name="graphql" class="internal-anchor"><h2>Implementation using GraphQL APIs</h2></a>
 
 <table class="table table-striped">
     <tr>
@@ -269,7 +269,7 @@ const token = "&lt;SET_TOKEN&gt;"
 const query = 
     `query getImagesFromWorkspace($workspaceId: String!){
         elements(workspaceId: $workspaceId, type: Image) {
-    __  typename
+        __typename
         id
         name
         }

--- a/site-templates/pages/get-list-of-workspaces.gomd
+++ b/site-templates/pages/get-list-of-workspaces.gomd
@@ -1,14 +1,13 @@
 <h1>Get the list of your workspaces</h1>
 
 <p>
-<b>Objective</b>: get a list of all Workspaces you can access. You do not need to know your userId to perform this operation. From this list you can retrieve the workspace IDs to use on other APIs that require you to have the Workspace ID. This is a good test to verify the functionality of your Access Token.
-If you are looking for the GraphQL section of this guide, click <a href="#graphql">here</a>.
+<b>Objective</b>: get a list of all Workspaces you can access. You do not need to know your userId to perform this operation. From this list you can retrieve the workspace IDs to use on other APIs that require you to have the Workspace ID. This is a good test to verify the functionality of your Access Token.<br />
+This page contains the implementation details for <a href="#rest">REST APIs</a> and for <a href="#graphql">GraphQL APIs</a>.
 </p>
 
 <p>
     All API endpoints share the same base URL:
 </p>
-
 
 <pre>
 <script type="text/javascript">document.write(apiBaseStr); </script>
@@ -18,7 +17,7 @@ If you are looking for the GraphQL section of this guide, click <a href="#graphq
 After you receive the authentication token, you can get a list of all the workspaces you can access.
 </p>
 
-<h2>REST</h2>
+<a name="rest" class="internal-anchor"><h2>Implementation using REST APIs</h2></a>
 
 <table class="table table-striped">
   <tr>
@@ -190,7 +189,7 @@ What you should get: JSON with the list of the first 25 workspaces your user has
 }
 </pre>
 
-<a name="graphql" class="internal-anchor"><h2>GraphQL</h2></a>
+<a name="graphql" class="internal-anchor"><h2>Implementation using GraphQL APIs</h2></a>
 
 <table class="table table-striped">
     <tr>


### PR DESCRIPTION
* Adding a small section with links for both REST and GraphQL sections inside the page:
<img width="597" alt="image" src="https://user-images.githubusercontent.com/51762982/116168886-57abc400-a6b8-11eb-9039-754dd69cb7e4.png">
* Changing titles of sections to "Implementation with REST APIs" and "Implementation with GraphQL APIs"
