### PR TITLE
Top nav: rename 'Partners' to 'Community' and change link, CE-796

### DIFF
--- a/site-templates/fragments/header.gohtml
+++ b/site-templates/fragments/header.gohtml
@@ -10,7 +10,7 @@
             <li><a href="/docs/page/reference-v2">Reference</a></li>
             <li><a href="/docs/page/appRegistration">Application Registration</a></li>
             <li><a href="https://partnercentral.bluescape.com/" target="_blank">Partner Central</a></li>
-            <li><a href="https://www.bluescape.com/partners/" target="_blank">Partners</a></li>
+            <li><a href="https://community.developer.bluescape.com/" target="_blank">Community</a></li>
 	        <li><a href="/docs/page/support">Support</a></li>
         </ul>
     </nav>   


### PR DESCRIPTION
Do not merge until top navigation links in https://community.developer.bluescape.com/ are fixed.