### PR TITLE
Dev/vlad/ce 939 enable search dev portal: templates and CSS

### DIFF
--- a/site-templates/assets/js/search.js
+++ b/site-templates/assets/js/search.js
@@ -1,0 +1,12 @@
+// Docs for options and further customization can be found:
+// https://fomantic-ui.com/modules/search.html
+$(document).ready(function () {
+    $('.ui.search')
+        .search({
+            apiSettings: {
+                url: '/docs/api/search?term={query}'
+            },
+            maxResults: 7,
+            minCharacters: 2,
+        });
+});

--- a/site-templates/fragments/header.gohtml
+++ b/site-templates/fragments/header.gohtml
@@ -5,6 +5,7 @@
         <span class="REBUILD #: 1"><b>Developer</b></span>
     <nav class="c-header__nav">
         <ul>
+            <li><b style="color:red">WITH SEARCH!</b></li>
             <li><a href="/docs/page/overview">Overview</a></li>
             <li><a href="/docs/page/guides">Guides</a></li>
             <li><a href="/docs/page/reference-v2">Reference</a></li>
@@ -13,7 +14,22 @@
             <li><a href="https://community.developer.bluescape.com/" target="_blank">Community</a></li>
 	        <li><a href="/docs/page/support">Support</a></li>
         </ul>
-    </nav>   
+    </nav>
+    <div class="c-header__misc">
+        <ul>
+            <div class="ui search">
+              <div class="ui icon input">
+                <input class="prompt" type="text" placeholder="Search">
+                <i class="search icon"></i>
+              </div>
+              <div class="results"></div>
+            </div>
+        </ul>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.7/dist/semantic.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.7/dist/semantic.min.js"></script>
+    <script src="{{$.Prefix}}assets/js/search.js"></script>     
 </header>
 
 <!-- JavaScripts -->

--- a/site-templates/layout.gohtml
+++ b/site-templates/layout.gohtml
@@ -21,6 +21,29 @@
     <link rel="stylesheet" type="text/css" media="screen" href="//stackpath.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" media="screen" href="//netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.css" />
     <link rel="stylesheet" href="{{.Prefix}}styles/master.css" type="text/css" media="all">
+    <!--this is required so the deep linking in the swagger docs works-->
+    <!--i had no success making this an imported stylesheet, so that's why it is inline-->
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
     {{if eq .Ctx "landing"}} {{template "landing-head" $}}
     {{else if eq .Ctx "page"}} {{template "page-magic-head" $}}
     {{else if eq .Ctx "doc"}} {{template "swagger-head" $}}

--- a/site-templates/styles/components/header.css
+++ b/site-templates/styles/components/header.css
@@ -43,7 +43,7 @@
 .c-header__misc {
   margin-left: auto;
   display: inline-flex;
-  align-items: center
+  align-items: center;
 }
 
 .c-header__misc > * {


### PR DESCRIPTION
Changes based on templates for Search, found in Datawire: https://github.com/datawire/devportal-content-v2/
Contact: Alice Wasko, Datawire Support

These changes require these Infrastructure changes to be done: https://github.com/Bluescape/infrastructure/pull/2541
* change Ambassador to Dev build that contains fix for Search
* enable search in UAD

@NoahBluescape : these are the changes to enable Search.