### PR TITLE
Dev/vlad/pse 72 how to use execute button in openapi docs

### DIFF
--- a/site-templates/fragments/swagger.gohtml
+++ b/site-templates/fragments/swagger.gohtml
@@ -6,9 +6,9 @@
     <link rel="stylesheet" type="text/css" href="{{.Prefix}}styles/components/swagger.css" >
     <script>
 
-        console.log("here 10.52 !");
-
         var GETrunOK = false;       
+        const apiBaseStrDomanin = window.location.hostname.split('.').splice(1).join('.');
+        const fetchURL = 'https://api.' + apiBaseStrDomanin + '/v3/users/me';
 
         function waitForElement(elementPath, callBack){
             window.setTimeout(function(){
@@ -22,14 +22,23 @@
         
         // Check click on "Try it out" Button
         waitForElement("button.btn.try-out__btn",function(){
+
+            // MODAL
+            const modal = $("#js-modal");
+            const openBtn = $("#js-open");
+            const closeBtn = $("#js-close");
+            closeBtn.on("click", () => {
+                modal.removeClass("show");
+            });
+
+            // Click on "Try it out" button
             $(document).on("click","button.btn.try-out__btn", function(){
 
                 // The text is captured AFTER it changes from "Try it out" to "Cancel", so it gets "Cancel" in the line below
                 var buttonText = $(this).text();
 
-                // Runnign a simple GET to test if teh user is logged into Bluescape 
-                // TODO: add the script to capture the current environment, to change the domain of the GET below
-                fetch ("https://api.uat.alpha.dev.bluescape.io/v3/users/me")
+                // Runnign a simple GET to test if the user is logged into Bluescape 
+                fetch (fetchURL)
                 .then(response => {
                     if ( response.status  == 200 ) {
                         GETrunOK = true;
@@ -44,12 +53,13 @@
                 })
                 .finally( function() {
                     if ( !GETrunOK && (buttonText == "Cancel" ) ) {
-                        alert('To use the "Try it out" feature, first log into Bluescape for the authentication to work.');
+                        modal.addClass("show");
                     }
                 });
             });
 
         });
+
 
     </script>
 
@@ -70,6 +80,54 @@
         td {
             border: none;
         }
+
+        .modal {
+            opacity: 0;
+            visibility: hidden;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.6);
+            transition: opacity 0.7s ease-in-out, visiblity 0.7s ease-in-out;
+            z-index: 1;
+        }
+        .modal.show {
+            opacity: 1;
+            visibility: visible;
+        }
+        .modal-container {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            color: #333333;
+            background: #ffffff;
+            width: 50%;
+            height: 250px;
+            text-align: center;
+            padding: 30px 50px;
+        }
+        .modal-inner {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: inherit;
+        }
+        .modal-title {
+            margin-bottom: 10px;
+        }
+        .modal-text {
+            margin-bottom: 20px;
+        }
+        .modal-close {
+            padding: 10px 20px;
+            background: #333333;
+            color: #ffffff;
+        }
+
     </style>
 {{end}}
 <span id="swagger-ui"></span>
@@ -86,3 +144,17 @@
  });
  
 </script>
+
+<div id="js-modal" class="modal">
+  <div class="modal-container">
+    <div class="modal-inner">
+      <p class="modal-text">To use the "Try it out" feature, first log into Bluescape for the authentication to work.<br />
+      See more details in this Bluescape Community <a target="_blank" href="https://community.bluescape.com/t/run-the-rest-apis-directly-from-the-developer-portal-use-the-try-it-out-button/360">article</a>.  
+      <br />
+        <button id="js-close" class="modal-close" type="button">
+            Close
+        </button>
+      </p>
+    </div>
+  </div>
+</div>

--- a/site-templates/fragments/swagger.gohtml
+++ b/site-templates/fragments/swagger.gohtml
@@ -1,8 +1,58 @@
 {{define "swagger-head"}}
+    <script src="https://code.jquery.com/jquery-1.11.3.js"></script> 
     <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
     <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css" >
     <link rel="stylesheet" type="text/css" href="{{.Prefix}}styles/components/swagger.css" >
+    <script>
+
+        console.log("here 10.52 !");
+
+        var GETrunOK = false;       
+
+        function waitForElement(elementPath, callBack){
+            window.setTimeout(function(){
+                if($(elementPath).length){
+                    callBack(elementPath, $(elementPath));
+                }else{
+                    waitForElement(elementPath, callBack);
+                }
+            },500)
+        };
+        
+        // Check click on "Try it out" Button
+        waitForElement("button.btn.try-out__btn",function(){
+            $(document).on("click","button.btn.try-out__btn", function(){
+
+                // The text is captured AFTER it changes from "Try it out" to "Cancel", so it gets "Cancel" in the line below
+                var buttonText = $(this).text();
+
+                // Runnign a simple GET to test if teh user is logged into Bluescape 
+                // TODO: add the script to capture the current environment, to change the domain of the GET below
+                fetch ("https://api.uat.alpha.dev.bluescape.io/v3/users/me")
+                .then(response => {
+                    if ( response.status  == 200 ) {
+                        GETrunOK = true;
+                    } else {
+                        GETrunOK = false;
+                    }
+                    return response.json()
+                })                
+                .catch((error) => {            
+                    console.error("BB - Error runnign GET");
+                    console.log(error);
+                })
+                .finally( function() {
+                    if ( !GETrunOK && (buttonText == "Cancel" ) ) {
+                        alert("To use this Execute option, remember to login into bluescape. [BB]");
+                    }
+                });
+            });
+
+        });
+
+    </script>
+
     <style>
         pre, span.pre {
             background-color: transparent;
@@ -23,7 +73,7 @@
     </style>
 {{end}}
 <span id="swagger-ui"></span>
-<script>
+<script> 
  const ui = SwaggerUIBundle({
      url: "/openapi/services/{{.CurrentNamespace}}/{{.CurrentService}}/openapi.json",
      dom_id: '#swagger-ui',
@@ -33,5 +83,6 @@
          SwaggerUIBundle.SwaggerUIStandalonePreset
 
      ],
- })
+ });
+ 
 </script>

--- a/site-templates/fragments/swagger.gohtml
+++ b/site-templates/fragments/swagger.gohtml
@@ -39,12 +39,12 @@
                     return response.json()
                 })                
                 .catch((error) => {            
-                    console.error("BB - Error runnign GET");
+                    console.error("Error runnign GET call to Bluescape");
                     console.log(error);
                 })
                 .finally( function() {
                     if ( !GETrunOK && (buttonText == "Cancel" ) ) {
-                        alert("To use this Execute option, remember to login into bluescape. [BB]");
+                        alert('To use the "Try it out" feature, first log into Bluescape for the authentication to work.');
                     }
                 });
             });


### PR DESCRIPTION
https://jira.common.bluescape.com/browse/PSE-72:
When in an opeapi.json documents (e.g.), when you expand a path and click the "Try it out" button:
* If the user is not logged into Bluescape already, a message pops up to warn the user that the APIs will not run correctly until they log into Bluescape. The will get a message 401 if they execute the API
* If the user logged into Bluescape already or after the message, then the API execution is already authorized, no message pops up.